### PR TITLE
fade fullscreen button in after timeline has settled

### DIFF
--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.NDLATimeline",
   "majorVersion": 0,
   "minorVersion": 0,
-  "patchVersion": 23,
+  "patchVersion": 24,
   "runnable": 1,
   "fullscreen": 1,
   "preloadedJs": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -17891,8 +17891,8 @@
       }
     },
     "node_modules/h5p-types": {
-      "version": "0.0.4",
-      "resolved": "git+ssh://git@github.com/boyum/h5p-types.git#114bef03d35b9c4b5a672e99b8937f3fe6fb1156",
+      "version": "0.0.6",
+      "resolved": "git+ssh://git@github.com/boyum/h5p-types.git#2b381bd88e4b047e9c7e089b42d80f1d1b27eb6d",
       "dependencies": {
         "@types/jquery": "^3.5.14"
       }
@@ -43749,7 +43749,7 @@
       }
     },
     "h5p-types": {
-      "version": "git+ssh://git@github.com/boyum/h5p-types.git#114bef03d35b9c4b5a672e99b8937f3fe6fb1156",
+      "version": "git+ssh://git@github.com/boyum/h5p-types.git#2b381bd88e4b047e9c7e089b42d80f1d1b27eb6d",
       "from": "h5p-types@github:boyum/h5p-types",
       "requires": {
         "@types/jquery": "^3.5.14"

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -14,3 +14,20 @@
     max-width: 80rem !important;
   }
 }
+
+/**
+ * Fade fullscreen button in after the timeline has settled.
+ * Only then, it can handle being resized to fullscreen.
+ */
+.h5p-enable-fullscreen {
+  animation: h5p-timeline-fade-in 0.15s 2s ease-in-out forwards;
+  opacity: 0;
+  pointer-events: none;
+}
+
+@keyframes h5p-timeline-fade-in {
+  100% {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -13,21 +13,33 @@
   .tl-slide-content {
     max-width: 80rem !important;
   }
-}
 
-/**
+  /**
  * Fade fullscreen button in after the timeline has settled.
  * Only then, it can handle being resized to fullscreen.
  */
-.h5p-enable-fullscreen {
-  animation: h5p-timeline-fade-in 0.15s 2s ease-in-out forwards;
-  opacity: 0;
-  pointer-events: none;
-}
+  .h5p-enable-fullscreen {
+    animation: h5p-timeline-fade-in 0.15s 2s ease-in-out forwards;
+    opacity: 0;
+    pointer-events: none;
+  }
 
-@keyframes h5p-timeline-fade-in {
-  100% {
-    opacity: 1;
-    pointer-events: auto;
+  @keyframes h5p-timeline-fade-in {
+    100% {
+      opacity: 1;
+      pointer-events: auto;
+    }
+  }
+
+  /**
+   * {1} We want to keep the content controls rendered, but hidden to not
+   *     re-trigger the fullscreen button fade-in animation any time fullscreen
+   *     mode is turned off
+   */
+  &.h5p-fullscreen {
+    .h5p-content-controls {
+      display: block; /* {1} */
+      z-index: 1;
+    }
   }
 }


### PR DESCRIPTION
When the timeline has rendered and is ready for use, it can handle
being resized by the fullscreen mode and will cover the screen
correctly.