### PR TITLE
Add alt tag option for images

### DIFF
--- a/language/.en.json
+++ b/language/.en.json
@@ -165,6 +165,10 @@
           "label": "Image"
         },
         {
+          "label": "Alternative text",
+          "description": "Required. If the browser can't load the image this text will be displayed instead. Also used by \"text-to-speech\" readers."
+        },
+        {
           "label": "Video"
         },
         {
@@ -373,6 +377,10 @@
           },
           {
             "label": "Image"
+          },
+          {
+            "label": "Alternative text",
+            "description": "Required. If the browser can't load the image this text will be displayed instead. Also used by \"text-to-speech\" readers."
           },
           {
             "label": "Video"

--- a/language/nb.json
+++ b/language/nb.json
@@ -165,6 +165,10 @@
           "label": "Bilde"
         },
         {
+          "label": "Alternativ tekst",
+          "description": "Påkrevd. Hvis bildet ikke kan lastes vises denne teksten istedenfor. Denne blir også brukt ved talesyntese."
+        },
+        {
           "label": "Video"
         },
         {
@@ -373,6 +377,10 @@
           },
           {
             "label": "Bilde"
+          },
+          {
+            "label": "Alternativ tekst",
+            "description": "Påkrevd. Hvis bildet ikke kan lastes vises denne teksten istedenfor. Denne blir også brukt ved talesyntese."
           },
           {
             "label": "Video"

--- a/language/nn.json
+++ b/language/nn.json
@@ -165,6 +165,10 @@
           "label": "Bilete"
         },
         {
+          "label": "Alternativ tekst",
+          "description": "Viss biletet ikkje kan lastast, blir denne teksten vist i istadenfor. Denne blir og nytta ved talesyntese."
+        },
+        {
           "label": "Video"
         },
         {
@@ -373,6 +377,10 @@
           },
           {
             "label": "Bilete"
+          },
+          {
+            "label": "Alternativ tekst",
+            "description": "Viss biletet ikkje kan lastast, blir denne teksten vist i istadenfor. Denne blir og nytta ved talesyntese."
           },
           {
             "label": "Video"

--- a/semantics.json
+++ b/semantics.json
@@ -297,6 +297,21 @@
         }
       },
       {
+        "label": "Alternative text",
+        "description": "Required. If the browser can't load the image this text will be displayed instead. Also used by \"text-to-speech\" readers.",
+        "name": "imageAlt",
+        "type": "text",
+        "widget": "NDLAShowWhen",
+        "showWhen": {
+          "rules": [
+            {
+              "field": "mediaType",
+              "equals": "image"
+            }
+          ]
+        }
+      },
+      {
         "label": "Video",
         "name": "video",
         "type": "video",
@@ -757,6 +772,21 @@
           "label": "Image",
           "name": "image",
           "type": "image",
+          "widget": "NDLAShowWhen",
+          "showWhen": {
+            "rules": [
+              {
+                "field": "mediaType",
+                "equals": "image"
+              }
+            ]
+          }
+        },
+        {
+          "label": "Alternative text",
+          "description": "Required. If the browser can't load the image this text will be displayed instead. Also used by \"text-to-speech\" readers.",
+          "name": "imageAlt",
+          "type": "text",
           "widget": "NDLAShowWhen",
           "showWhen": {
             "rules": [

--- a/src/types/MediaType.ts
+++ b/src/types/MediaType.ts
@@ -4,6 +4,7 @@ export type MediaType =
   | {
       mediaType: "image";
       image?: Image;
+      imageAlt?: string;
     }
   | {
       mediaType: "video";

--- a/src/utils/timeline.utils.tsx
+++ b/src/utils/timeline.utils.tsx
@@ -170,6 +170,7 @@ export const mapEventToTimelineSlide = (
   if (media) {
     slide.media = {
       url: typeof media === "string" ? media : media.path,
+      alt: event.mediaType === "image" ? event.imageAlt : undefined,
     };
   }
 


### PR DESCRIPTION
When merged in, authors will be able to assign alternative texts to images in order to improve accessibility.